### PR TITLE
Create the-chemical-society-of-japan.csl

### DIFF
--- a/the-chemical-society-of-japan.csl
+++ b/the-chemical-society-of-japan.csl
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>The Chemical Society of Japan</title>
+    <id>http://www.zotero.org/styles/styles/the-chemical-society-of-japan</id>
+    <link href="http://www.zotero.org/styles/the-chemical-society-of-japan" rel="self"/>
+    <link href="http://www.csj.jp/journals/styles/ref.html" rel="documentation"/>
+    <author>
+      <name>Shoji Takahashi</name>
+      <email>s.takahashi@elsevier.com</email>
+      <uri>http://www.mendeley.com/profiles/shoji-takahashi3/</uri>
+    </author>
+    <category citation-format="numeric"/>
+	<category field="chemistry"/>
+    <updated>2015-12-04T01:42:50+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name initialize-with=". "/>
+    </names>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="container-title" form="short" font-style="italic" suffix=" "/>
+      </if>
+      <else-if type="book" match="any">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <text term="in" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="container-title" font-style="normal"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <number suffix=" " variable="edition" form="ordinal"/>
+    <label plural="never" variable="edition" form="short"/>
+  </macro>
+  <macro name="event">
+    <text variable="event-place" suffix=", "/>
+    <date variable="event-date">
+      <date-part name="month" range-delimiter="" suffix=" "/>
+      <date-part name="day" range-delimiter="" suffix=", "/>
+      <date-part name="year" range-delimiter="" font-weight="bold"/>
+    </date>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book article" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <date date-parts="year" form="numeric" variable="issued" font-weight="normal">
+      <date-part name="year" font-weight="bold"/>
+    </date>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="verb-short" plural="never" suffix=" "/>
+      <name initialize="false" initialize-with=". "/>
+    </names>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal" match="any">
+        <number font-style="italic" variable="volume"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <text term="volume" form="short" text-case="capitalize-first" font-style="normal" suffix=" "/>
+        <number suffix=", " variable="volume"/>
+        <text term="chapter" form="short" text-case="capitalize-first" suffix=" "/>
+        <number variable="chapter-number"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="page">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="page-first"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <label suffix=" " variable="page" form="short"/>
+        <text variable="page"/>
+      </else-if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher" suffix=", "/>
+    <text variable="publisher-place"/>
+  </macro>
+  <citation collapse="citation-number">
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout suffix=".">
+      <text variable="citation-number"/>
+      <text macro="author" suffix=", "/>
+      <choose>
+        <if type="article-journal">
+          <text macro="container-title" suffix=" "/>
+          <group delimiter=", ">
+            <text macro="issued"/>
+            <text macro="locators"/>
+            <text macro="page"/>
+          </group>
+        </if>
+        <else-if type="book" match="any">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="edition" suffix=" "/>
+            <text macro="editor"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+          </group>
+        </else-if>
+        <else-if type="chapter" match="any">
+          <group delimiter=", ">
+            <text macro="container-title"/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+            <text macro="locators"/>
+            <text macro="page"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference" match="any">
+          <group delimiter=", ">
+            <text macro="container-title"/>
+            <text macro="event"/>
+            <text macro="page"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=", ">
+            <text variable="number"/>
+            <text macro="issued"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text variable="genre"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+          </group>
+        </else-if>
+        <else-if type="article" match="any">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+          </group>
+        </else-if>
+        <else-if type="webpage" match="any">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="URL"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+            <text macro="page"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This style is for the two journals published by The Chemical Society of Japan.
- Bulletin of the Chemical Society of Japan
- Chemistry Letters
  The dependent styles for these journals will be submitted separately.

Shoji Takahashi
Solution Consultant (e-Platform and Content), A&G
Elsevier Japan KK
E-mail: s.takahashi@elsevier.com
